### PR TITLE
fix for the TotalMoneyEarned bug

### DIFF
--- a/QuestEssentials/Framework/Patches.cs
+++ b/QuestEssentials/Framework/Patches.cs
@@ -108,7 +108,6 @@ namespace QuestEssentials.Framework
         public static void Before_set_Money(Farmer __instance, int value)
         {
             int oldMoney = __instance._money;
-            __instance._money = value;
 
             if (value <= oldMoney)
                 return;


### PR DESCRIPTION
QE causes the "TotalMoneyEarned" to never increase because the prefix set the var `player._money`, which was used by the `player.Money` setter to check how much money was earned  to add it to TotalMoneyEarned. This PR removes that line.